### PR TITLE
Define Less variables that are undefined when Bootstrap is absent

### DIFF
--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -1,5 +1,10 @@
 @topbarHeight: 50px;
+@shadow: 0px 6px 12px rgba(0, 0, 0, 0.5);
 
+.box-shadow(@shadow) {
+	-webkit-box-shadow: @shadow;
+			box-shadow: @shadow;
+}
 
 html.composing {
 	&.mobile {
@@ -59,8 +64,8 @@ html.composing {
 		}
 
 		.mobile-navbar {
-			background: @btn-primary-bg;
-			color: @btn-primary-color;
+			background: #337ab7;
+			color: #fff;
 			position: absolute;
 
 			button {
@@ -220,7 +225,7 @@ html.composing {
 		.spacer {
 			&:before {
 				content: ' | ';
-				color: @gray-light;
+				color: #777;
 			}
 		}
 	}


### PR DESCRIPTION
The plugin makes use of some Bootstrap Less variables. When Bootstrap isn't used, these variables are undefined resulting in NodeBB not running. Bootstrap is used by the default theme so we only notice the problem when we try to develop custom themes that don't use Bootstrap.

The PR replaces the variables with the default values assigned to them by Bootstrap.

The plugin also expects a parametric mixin which doesn't exist. I have defined that in composer.less.