### PR TITLE
rtrim appears to be deprecated and renamed to trimRight.

### DIFF
--- a/static/lib/composer.js
+++ b/static/lib/composer.js
@@ -509,7 +509,7 @@ define('composer', [
 		options = options || {};
 
 		titleEl.val(titleEl.val().trim());
-		bodyEl.val(bodyEl.val().rtrim());
+		bodyEl.val(bodyEl.val().trimRight());
 		if (thumbEl.length) {
 			thumbEl.val(thumbEl.val().trim());
 		}


### PR DESCRIPTION
I couldn't post anything on my site anymore and when I inspected the javascript console it was because rtrim wasn't defined.  I saw in the string changelog that it's been renamed to trimRight