### PR TITLE
Switch from `translate` to `top`, various script improvements

### DIFF
--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -65,7 +65,7 @@ html.composing {
 
 			button {
 				font-size: 20px;
-			}	
+			}
 		}
 	}
 
@@ -78,11 +78,11 @@ html.composing {
 	.no-select;
 
 	position: fixed;
-	bottom: 0px;
-
-	right: 0px;
-	width: 100%;
-	height: 100%;
+	bottom: 0;
+	top: 0;
+	right: 0;
+	left: 0;
+	
 	z-index: 10000;
 
 	padding-top: 20px;
@@ -230,7 +230,7 @@ html.composing {
 		width: 100%;
 		top: 10px;
 		height: 0px;
-		
+
 		.pointer;
 
 		.trigger {
@@ -261,7 +261,7 @@ html.composing {
 	}
 
 	&.maximized {
-		.resizer .trigger i {		
+		.resizer .trigger i {
 			&:before {
 				content: @fa-var-chevron-down;
 			}

--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -79,7 +79,7 @@ html.composing {
 
 	position: fixed;
 	bottom: 0;
-	top: 50%;
+	top: 0;
 	right: 0;
 	left: 0;
 

--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -79,10 +79,10 @@ html.composing {
 
 	position: fixed;
 	bottom: 0;
-	top: 0;
+	top: 50%;
 	right: 0;
 	left: 0;
-	
+
 	z-index: 10000;
 
 	padding-top: 20px;

--- a/static/lib/composer/resize.js
+++ b/static/lib/composer/resize.js
@@ -47,8 +47,6 @@ define('composer/resize', ['autosize'], function(autosize) {
 
 			var windowHeight = $window.height();
 
-			console.log(percentage);
-
 			if (percentage < minimumPercentage) {
 				percentage = minimumPercentage;
 			} else if (percentage >= 1) {

--- a/static/lib/composer/resize.js
+++ b/static/lib/composer/resize.js
@@ -5,10 +5,22 @@
 
 define('composer/resize', ['autosize'], function(autosize) {
 	var resize = {},
-		oldPercentage = 0;
+		oldPercentage = 0,
+		minimumPercentage = 0.3,
+		snapMargin = 1/15;
+
+	var $body = $('body'),
+		$html = $('html'),
+		$window = $(window),
+		$headerMenu = $('#header-menu');
+
 
 	resize.reposition = function(postContainer) {
 		var	percentage = localStorage.getItem('composer:resizePercentage') || 0.5;
+
+		if (percentage >= 1 - snapMargin) {
+			postContainer.addClass('maximized');
+		}
 
 		doResize(postContainer, percentage);
 	};
@@ -19,31 +31,35 @@ define('composer/resize', ['autosize'], function(autosize) {
 
 		// todo, lump in browsers that don't support transform (ie8) here
 		// at this point we should use modernizr
+
+		// done, just use `top` instead of `translate`
+
 		if (env === 'sm' || env === 'xs' || window.innerHeight < 480) {
-			$('html').addClass('composing mobile');
+			$html.addClass('composing mobile');
 			autosize(postContainer.find('textarea')[0]);
 			percentage = 1;
 		} else {
-			$('html').removeClass('composing mobile');
+			$html.removeClass('composing mobile');
 		}
 
 		if (percentage) {
-			var max = getMaximumPercentage();
+			var upperBound = getUpperBound();
 
-			if (percentage < 0.25) {
-				percentage = 0.25;
-			} else if (percentage > max) {
-				percentage = max;
+			var windowHeight = $window.height();
+
+			console.log(percentage);
+
+			if (percentage < minimumPercentage) {
+				percentage = minimumPercentage;
+			} else if (percentage >= 1) {
+				percentage = 1;
 			}
 
 			if (env === 'md' || env === 'lg') {
-				var transform = 'translate(0, ' + (Math.abs(1-percentage) * 100) + '%)';
+				var top = percentage * (windowHeight - upperBound) / windowHeight;
+				top = (Math.abs(1-top) * 100) + '%';
 				postContainer.css({
-					'-webkit-transform': transform,
-					'-moz-transform': transform,
-					'-ms-transform': transform,
-					'-o-transform': transform,
-					'transform': transform
+					'top': top
 				});
 			} else {
 				postContainer.removeAttr('style');
@@ -65,12 +81,27 @@ define('composer/resize', ['autosize'], function(autosize) {
 		postContainer.css('visibility', 'visible');
 
 		// Add some extra space at the bottom of the body so that the user can still scroll to the last post w/ composer open
-		$('body').css({'margin-bottom': postContainer.css('height')});
+		$body.css({ 'margin-bottom': postContainer.outerHeight() });
 
 		resizeWritePreview(postContainer);
 	}
 
+	var resizeIt = doResize;
+
+	var raf = window.requestAnimationFrame ||
+					window.webkitRequestAnimationFrame ||
+					window.mozRequestAnimationFrame;
+
+	if (raf) {
+		resizeIt = function(postContainer, percentage) {
+			raf(function() {
+				doResize(postContainer, percentage);
+			});
+		};
+	}
+
 	resize.handleResize = function(postContainer) {
+
 		function resizeStart(e) {
 			var resizeRect = resizeEl[0].getBoundingClientRect(),
 				resizeCenterY = resizeRect.top + (resizeRect.height / 2);
@@ -79,42 +110,46 @@ define('composer/resize', ['autosize'], function(autosize) {
 			resizeActive = true;
 			resizeDown = e.clientY;
 
-			$(window).on('mousemove', resizeAction);
-			$(window).on('mouseup', resizeStop);
-			$('body').on('touchmove', resizeTouchAction);
+			$window.on('mousemove', resizeAction);
+			$window.on('mouseup', resizeStop);
+			$body.on('touchmove', resizeTouchAction);
 		}
 
 		function resizeStop(e) {
 			resizeActive = false;
 
 			postContainer.find('textarea').focus();
-			$(window).off('mousemove', resizeAction);
-			$(window).off('mouseup', resizeStop);
-			$('body').off('touchmove', resizeTouchAction);
+			$window.off('mousemove', resizeAction);
+			$window.off('mouseup', resizeStop);
+			$body.off('touchmove', resizeTouchAction);
 
 			var position = (e.clientY - resizeOffset),
-				newHeight = $(window).height() - position,
-				windowHeight = $(window).height();
+				windowHeight = $window.height(),
+				upperBound = getUpperBound(),
+				newHeight = windowHeight - position,
+				ratio = newHeight / (windowHeight - upperBound);
 
-			if (newHeight > windowHeight - $('#header-menu').height() - (windowHeight / 15)) {
+			if (ratio >= 1 - snapMargin) {
 				snapToTop = true;
 			} else {
 				snapToTop = false;
 			}
+
+			resizeSavePosition(ratio);
 
 			toggleMaximize(e);
 		}
 
 		function toggleMaximize(e) {
 			if (e.clientY - resizeDown === 0 || snapToTop) {
-				var newPercentage = getMaximumPercentage();
+				var newPercentage = 1;
 
 				if (!postContainer.hasClass('maximized') || !snapToTop) {
 					oldPercentage = postContainer.percentage;
-					doResize(postContainer, newPercentage);
+					resizeIt(postContainer, newPercentage);
 					postContainer.addClass('maximized');
 				} else {
-					doResize(postContainer, oldPercentage);
+					resizeIt(postContainer, (oldPercentage >= 1 - snapMargin) ? 0.5 : oldPercentage);
 					postContainer.removeClass('maximized');
 				}
 			}
@@ -128,12 +163,14 @@ define('composer/resize', ['autosize'], function(autosize) {
 		function resizeAction(e) {
 			if (resizeActive) {
 				var position = (e.clientY - resizeOffset),
-					newHeight = $(window).height() - position;
+					windowHeight = $window.height(),
+					upperBound = getUpperBound(),
+					newHeight = windowHeight - position,
+					ratio = newHeight / (windowHeight - upperBound);
 
-				doResize(postContainer, newHeight / $(window).height());
+				resizeIt(postContainer, ratio);
 
 				resizeWritePreview(postContainer);
-				resizeSavePosition(newHeight);
 
 				if (Math.abs(e.clientY - resizeDown) > 0) {
 					postContainer.removeClass('maximized');
@@ -144,16 +181,14 @@ define('composer/resize', ['autosize'], function(autosize) {
 			return false;
 		}
 
-		function resizeSavePosition(px) {
-			var	percentage = px / $(window).height(),
-				max = getMaximumPercentage();
-			localStorage.setItem('composer:resizePercentage', percentage < max ? percentage : max);
+		function resizeSavePosition(percentage) {
+			localStorage.setItem('composer:resizePercentage', percentage <= 1 ? percentage : 1);
 		}
 
 		var	resizeActive = false,
 			resizeOffset = 0,
-            resizeDown = 0,
-            snapToTop = false,
+			resizeDown = 0,
+			snapToTop = false,
 			resizeEl = postContainer.find('.resizer');
 
 		resizeEl
@@ -168,19 +203,19 @@ define('composer/resize', ['autosize'], function(autosize) {
 			});
 	};
 
-	function getMaximumPercentage() {
-		return ($(window).height() - $('#header-menu').height() - 1) / $(window).height();
+	function getUpperBound() {
+		return $headerMenu.height() + 1;
 	}
 
 	function resizeWritePreview(postContainer) {
 		var total = getFormattingHeight(postContainer),
-			containerHeight = postContainer.percentage * $(window).height() - $('#header-menu').height() - total;
+			containerHeight = postContainer.height() + 20 - total;
 
 		postContainer
 			.find('.write-preview-container')
 			.css('height', containerHeight);
 
-		$(window).trigger('action:composer.resize', {
+		$window.trigger('action:composer.resize', {
 			formattingHeight: total,
 			containerHeight: containerHeight
 		});


### PR DESCRIPTION
Less file changes

- Switch to using opposite fixed positioning instead of `height` and `width`
- Some whitespace changes my editor made

Changes to script

- Define constants at the top
- Cache your jQuery objects
- Start the thing maximized if the last position was near the top
- Change how the percentage is used / passed around from the actual percentage to the percentage within the available area
- Use `top` instead of `transform`
- Use `window.requestAnimationFrame` for smoother dragging
- Just check the ratio instead of calculating with pixels
- Fixed the "Hugh Jass" white void at the bottom of the body
- If the `oldPercentage` is within the snap margin, just drop it down to 50% instead
- Change how the `containerHeight` was calculated to something simpler

Overall, major speed improvements. I think using CSS in more places would really help, like when fitting the `.write-preview-container`, although this would require more absolute positioning hacks (but could speed stuff up significantly).

For a lot of things, you'd be better just listening for changes and caching the values, which would also speed things up a bit.