### PR TITLE
CSS / perf improvements

### DIFF
--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -65,7 +65,7 @@ html.composing {
 
 			button {
 				font-size: 20px;
-			}	
+			}
 		}
 	}
 
@@ -78,11 +78,11 @@ html.composing {
 	.no-select;
 
 	position: fixed;
-	bottom: 0px;
-
-	right: 0px;
-	width: 100%;
-	height: 100%;
+	bottom: 0;
+	top: 0;
+	right: 0;
+	left: 0;
+	
 	z-index: 10000;
 
 	padding-top: 20px;
@@ -230,7 +230,7 @@ html.composing {
 		width: 100%;
 		top: 10px;
 		height: 0px;
-		
+
 		.pointer;
 
 		.trigger {
@@ -261,7 +261,7 @@ html.composing {
 	}
 
 	&.maximized {
-		.resizer .trigger i {		
+		.resizer .trigger i {
 			&:before {
 				content: @fa-var-chevron-down;
 			}

--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -1,13 +1,38 @@
 @topbarHeight: 50px;
 
-
 html.composing {
-	&.mobile {
-		overflow: hidden;
+
+	@media (max-width: @screen-sm-max) {
+		& {
+			overflow: hidden;
+		}
 
 		.composer {
 			position: absolute;
 			box-shadow: none;
+			top: 0 !important;
+		}
+
+		.composer-container {
+			.write {
+				padding-bottom: 25px;
+			}
+
+			.write-preview-container {
+				left: 0;
+				right: 0;
+				height: auto;
+				bottom: 0;
+				overflow: scroll;
+
+				top: 103px;
+			}
+
+			&.topic-main {
+				.write-preview-container {
+					top: 226px;
+				}
+			}
 		}
 	}
 
@@ -66,6 +91,17 @@ html.composing {
 			button {
 				font-size: 20px;
 			}
+
+			.title {
+				margin: 0px;
+				line-height: 50px;
+				padding: 0px 10px;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				font-size: 22px;
+				font-weight: normal;
+			}
 		}
 	}
 
@@ -79,7 +115,7 @@ html.composing {
 
 	position: fixed;
 	bottom: 0;
-	top: 50%;
+	top: 0;
 	right: 0;
 	left: 0;
 
@@ -142,9 +178,20 @@ html.composing {
 	}
 
 	.write-preview-container {
-		height:100%;
+		height: 100%;
 		margin: 0 0;
 		min-height: 200px;
+
+		position: absolute;
+		left: 10px;
+		right: 10px;
+		height: auto;
+		bottom: 80px;
+		top: 140px;
+
+		@media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+			top: 217px;
+		}
 
 		> div {
 			height:100%;
@@ -157,7 +204,7 @@ html.composing {
 		.box-shadow(inset 0px 1px 1px rgba(0, 0, 0, 0.05));
 	}
 
-	.write, .preview  {
+	.write, .preview {
 		display: block;
 		width: 100%;
 		height: 100%;
@@ -166,7 +213,7 @@ html.composing {
 		-webkit-border-radius: 0px;
 		-moz-border-radius: 0px;
 		border-radius: 0px;
-		resize:none;
+		resize: none;
 		overflow: auto;
 		padding: 20px;
 	}
@@ -280,31 +327,31 @@ html.composing {
 		display: none;
 	}
 
-  .topic-thumb-container {
-    margin-top: 5px;
-    margin-left: 8px;
-    margin-right: 8px;
-    background: rgb(255, 255, 255);
-    background: rgba(255, 255, 255, 0.6);
-    padding: 10px;
-  }
+	.topic-thumb-container {
+		margin-top: 5px;
+		margin-left: 8px;
+		margin-right: 8px;
+		background: rgb(255, 255, 255);
+		background: rgba(255, 255, 255, 0.6);
+		padding: 10px;
+	}
 
-  .topic-thumb-btn {
-    cursor: hand;
-    cursor: pointer;
-  }
+	.topic-thumb-btn {
+		cursor: hand;
+		cursor: pointer;
+	}
 
-  .topic-thumb-preview {
-    width: auto;
-    height: auto;
-    max-width: 100px;
-    max-height: 100px
-  }
+	.topic-thumb-preview {
+		width: auto;
+		height: auto;
+		max-width: 100px;
+		max-height: 100px
+	}
 
-  .topic-thumb-ctrl.form-group {
-    display: inline-block;
-    vertical-align: -50% !important;
-  }
+	.topic-thumb-ctrl.form-group {
+		display: inline-block;
+		vertical-align: -50% !important;
+	}
 }
 
 @media (max-width: 767px), (max-height: 480px) {

--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -79,10 +79,10 @@ html.composing {
 
 	position: fixed;
 	bottom: 0;
-	top: 0;
+	top: 50%;
 	right: 0;
 	left: 0;
-	
+
 	z-index: 10000;
 
 	padding-top: 20px;

--- a/static/lib/composer/resize.js
+++ b/static/lib/composer/resize.js
@@ -47,8 +47,6 @@ define('composer/resize', ['autosize'], function(autosize) {
 
 			var windowHeight = $window.height();
 
-			console.log(percentage);
-
 			if (percentage < minimumPercentage) {
 				percentage = minimumPercentage;
 			} else if (percentage >= 1) {

--- a/static/lib/composer/resize.js
+++ b/static/lib/composer/resize.js
@@ -25,7 +25,7 @@ define('composer/resize', ['autosize'], function(autosize) {
 		doResize(postContainer, percentage);
 	};
 
-	function doResize(postContainer, percentage) {
+	function doResize(postContainer, percentage, realPercentage) {
 		var env = utils.findBootstrapEnvironment();
 
 
@@ -54,8 +54,14 @@ define('composer/resize', ['autosize'], function(autosize) {
 			}
 
 			if (env === 'md' || env === 'lg') {
-				var top = percentage * (windowHeight - upperBound) / windowHeight;
+				var top;
+				if (realPercentage) {
+					top = realPercentage;
+				} else {
+					top = percentage * (windowHeight - upperBound) / windowHeight;
+				}
 				top = (Math.abs(1-top) * 100) + '%';
+
 				postContainer.css({
 					'top': top
 				});
@@ -79,7 +85,7 @@ define('composer/resize', ['autosize'], function(autosize) {
 		postContainer.css('visibility', 'visible');
 
 		// Add some extra space at the bottom of the body so that the user can still scroll to the last post w/ composer open
-		$body.css({ 'margin-bottom': postContainer.outerHeight() });
+		$body.css({ 'margin-bottom': postContainer.height() + 20 });
 
 		resizeWritePreview(postContainer);
 	}
@@ -166,7 +172,7 @@ define('composer/resize', ['autosize'], function(autosize) {
 					newHeight = windowHeight - position,
 					ratio = newHeight / (windowHeight - upperBound);
 
-				resizeIt(postContainer, ratio);
+				resizeIt(postContainer, ratio, newHeight / windowHeight);
 
 				resizeWritePreview(postContainer);
 
@@ -206,30 +212,20 @@ define('composer/resize', ['autosize'], function(autosize) {
 	}
 
 	function resizeWritePreview(postContainer) {
-		var total = getFormattingHeight(postContainer),
-			containerHeight = postContainer.height() + 20 - total;
+		var container = postContainer
+			.find('.write-preview-container');
+		var contBox = container[0].getBoundingClientRect();
+		var outerBox = container.parent().parent()[0].getBoundingClientRect();
 
-		postContainer
-			.find('.write-preview-container')
-			.css('height', containerHeight);
+		var newHeight = (contBox.bottom - contBox.top) +
+			(outerBox.bottom - 30 - contBox.bottom );
+
+		container.css('height', newHeight);
 
 		$window.trigger('action:composer.resize', {
-			formattingHeight: total,
-			containerHeight: containerHeight
+			containerHeight: newHeight
 		});
 	}
-
-	function getFormattingHeight(postContainer) {
-		return [
-			postContainer.find('.title-container').outerHeight(true),
-			postContainer.find('.formatting-bar').outerHeight(true),
-			postContainer.find('.topic-thumb-container').outerHeight(true),
-			$('.taskbar').height()
-		].reduce(function(a, b) {
-			return a + b;
-		});
-	}
-
 
 	return resize;
 });

--- a/static/lib/composer/resize.js
+++ b/static/lib/composer/resize.js
@@ -14,7 +14,6 @@ define('composer/resize', ['autosize'], function(autosize) {
 		$window = $(window),
 		$headerMenu = $('#header-menu');
 
-
 	resize.reposition = function(postContainer) {
 		var	percentage = localStorage.getItem('composer:resizePercentage') || 0.5;
 
@@ -40,20 +39,18 @@ define('composer/resize', ['autosize'], function(autosize) {
 			percentage = 1;
 		} else {
 			$html.removeClass('composing mobile');
-		}
 
-		if (percentage) {
-			var upperBound = getUpperBound();
+			if (percentage) {
+				var upperBound = getUpperBound();
 
-			var windowHeight = $window.height();
+				var windowHeight = window.innerHeight;
 
-			if (percentage < minimumPercentage) {
-				percentage = minimumPercentage;
-			} else if (percentage >= 1) {
-				percentage = 1;
-			}
+				if (percentage < minimumPercentage) {
+					percentage = minimumPercentage;
+				} else if (percentage >= 1) {
+					percentage = 1;
+				}
 
-			if (env === 'md' || env === 'lg') {
 				var top;
 				if (realPercentage) {
 					top = realPercentage;
@@ -62,12 +59,12 @@ define('composer/resize', ['autosize'], function(autosize) {
 				}
 				top = (Math.abs(1-top) * 100) + '%';
 
-				postContainer.css({
-					'top': top
-				});
-			} else {
-				postContainer.removeAttr('style');
+				postContainer[0].style.top = top;
+
+				// Add some extra space at the bottom of the body so that the user can still scroll to the last post w/ composer open
+				$body[0].style.marginBottom = postContainer.height() + 20 + 'px';
 			}
+
 		}
 
 		postContainer.percentage = percentage;
@@ -82,12 +79,9 @@ define('composer/resize', ['autosize'], function(autosize) {
 			postContainer.find('#files.lt-ie9').removeClass('hide');
 		}
 
-		postContainer.css('visibility', 'visible');
+		postContainer[0].style.visibility = 'visible';
 
-		// Add some extra space at the bottom of the body so that the user can still scroll to the last post w/ composer open
-		$body.css({ 'margin-bottom': postContainer.height() + 20 });
-
-		resizeWritePreview(postContainer);
+		$window.trigger('action:composer.resize');
 	}
 
 	var resizeIt = doResize;
@@ -128,18 +122,18 @@ define('composer/resize', ['autosize'], function(autosize) {
 			$body.off('touchmove', resizeTouchAction);
 
 			var position = (e.clientY - resizeOffset),
-				windowHeight = $window.height(),
+				windowHeight = window.innerHeight,
 				upperBound = getUpperBound(),
 				newHeight = windowHeight - position,
-				ratio = newHeight / (windowHeight - upperBound);
+				percentage = newHeight / (windowHeight - upperBound);
 
-			if (ratio >= 1 - snapMargin) {
+			if (percentage >= 1 - snapMargin) {
 				snapToTop = true;
 			} else {
 				snapToTop = false;
 			}
 
-			resizeSavePosition(ratio);
+			resizeSavePosition(percentage);
 
 			toggleMaximize(e);
 		}
@@ -167,14 +161,12 @@ define('composer/resize', ['autosize'], function(autosize) {
 		function resizeAction(e) {
 			if (resizeActive) {
 				var position = (e.clientY - resizeOffset),
-					windowHeight = $window.height(),
+					windowHeight = window.innerHeight,
 					upperBound = getUpperBound(),
 					newHeight = windowHeight - position,
-					ratio = newHeight / (windowHeight - upperBound);
+					percentage = newHeight / (windowHeight - upperBound);
 
-				resizeIt(postContainer, ratio, newHeight / windowHeight);
-
-				resizeWritePreview(postContainer);
+				resizeIt(postContainer, percentage, newHeight / windowHeight);
 
 				if (Math.abs(e.clientY - resizeDown) > 0) {
 					postContainer.removeClass('maximized');
@@ -208,23 +200,7 @@ define('composer/resize', ['autosize'], function(autosize) {
 	};
 
 	function getUpperBound() {
-		return $headerMenu.height() + 1;
-	}
-
-	function resizeWritePreview(postContainer) {
-		var container = postContainer
-			.find('.write-preview-container');
-		var contBox = container[0].getBoundingClientRect();
-		var outerBox = container.parent().parent()[0].getBoundingClientRect();
-
-		var newHeight = (contBox.bottom - contBox.top) +
-			(outerBox.bottom - 30 - contBox.bottom );
-
-		container.css('height', newHeight);
-
-		$window.trigger('action:composer.resize', {
-			containerHeight: newHeight
-		});
+		return $headerMenu[0].getBoundingClientRect().bottom;
 	}
 
 	return resize;

--- a/static/lib/composer/resize.js
+++ b/static/lib/composer/resize.js
@@ -5,10 +5,22 @@
 
 define('composer/resize', ['autosize'], function(autosize) {
 	var resize = {},
-		oldPercentage = 0;
+		oldPercentage = 0,
+		minimumPercentage = 0.3,
+		snapMargin = 1/15;
+
+	var $body = $('body'),
+		$html = $('html'),
+		$window = $(window),
+		$headerMenu = $('#header-menu');
+
 
 	resize.reposition = function(postContainer) {
 		var	percentage = localStorage.getItem('composer:resizePercentage') || 0.5;
+
+		if (percentage >= 1 - snapMargin) {
+			postContainer.addClass('maximized');
+		}
 
 		doResize(postContainer, percentage);
 	};
@@ -19,31 +31,35 @@ define('composer/resize', ['autosize'], function(autosize) {
 
 		// todo, lump in browsers that don't support transform (ie8) here
 		// at this point we should use modernizr
+
+		// done, just use `top` instead of `translate`
+
 		if (env === 'sm' || env === 'xs' || window.innerHeight < 480) {
-			$('html').addClass('composing mobile');
+			$html.addClass('composing mobile');
 			autosize(postContainer.find('textarea')[0]);
 			percentage = 1;
 		} else {
-			$('html').removeClass('composing mobile');
+			$html.removeClass('composing mobile');
 		}
 
 		if (percentage) {
-			var max = getMaximumPercentage();
+			var upperBound = getUpperBound();
 
-			if (percentage < 0.25) {
-				percentage = 0.25;
-			} else if (percentage > max) {
-				percentage = max;
+			var windowHeight = $window.height();
+
+			console.log(percentage);
+
+			if (percentage < minimumPercentage) {
+				percentage = minimumPercentage;
+			} else if (percentage >= 1) {
+				percentage = 1;
 			}
 
 			if (env === 'md' || env === 'lg') {
-				var transform = 'translate(0, ' + (Math.abs(1-percentage) * 100) + '%)';
+				var top = percentage * (windowHeight - upperBound) / windowHeight;
+				top = (Math.abs(1-top) * 100) + '%';
 				postContainer.css({
-					'-webkit-transform': transform,
-					'-moz-transform': transform,
-					'-ms-transform': transform,
-					'-o-transform': transform,
-					'transform': transform
+					'top': top
 				});
 			} else {
 				postContainer.removeAttr('style');
@@ -65,12 +81,27 @@ define('composer/resize', ['autosize'], function(autosize) {
 		postContainer.css('visibility', 'visible');
 
 		// Add some extra space at the bottom of the body so that the user can still scroll to the last post w/ composer open
-		$('body').css({'margin-bottom': postContainer.css('height')});
+		$body.css({ 'margin-bottom': postContainer.outerHeight() });
 
 		resizeWritePreview(postContainer);
 	}
 
+	var resizeIt = doResize;
+
+	var raf = window.requestAnimationFrame ||
+					window.webkitRequestAnimationFrame ||
+					window.mozRequestAnimationFrame;
+
+	if (raf) {
+		resizeIt = function(postContainer, percentage) {
+			raf(function() {
+				doResize(postContainer, percentage);
+			});
+		};
+	}
+
 	resize.handleResize = function(postContainer) {
+
 		function resizeStart(e) {
 			var resizeRect = resizeEl[0].getBoundingClientRect(),
 				resizeCenterY = resizeRect.top + (resizeRect.height / 2);
@@ -79,42 +110,46 @@ define('composer/resize', ['autosize'], function(autosize) {
 			resizeActive = true;
 			resizeDown = e.clientY;
 
-			$(window).on('mousemove', resizeAction);
-			$(window).on('mouseup', resizeStop);
-			$('body').on('touchmove', resizeTouchAction);
+			$window.on('mousemove', resizeAction);
+			$window.on('mouseup', resizeStop);
+			$body.on('touchmove', resizeTouchAction);
 		}
 
 		function resizeStop(e) {
 			resizeActive = false;
 
 			postContainer.find('textarea').focus();
-			$(window).off('mousemove', resizeAction);
-			$(window).off('mouseup', resizeStop);
-			$('body').off('touchmove', resizeTouchAction);
+			$window.off('mousemove', resizeAction);
+			$window.off('mouseup', resizeStop);
+			$body.off('touchmove', resizeTouchAction);
 
 			var position = (e.clientY - resizeOffset),
-				newHeight = $(window).height() - position,
-				windowHeight = $(window).height();
+				windowHeight = $window.height(),
+				upperBound = getUpperBound(),
+				newHeight = windowHeight - position,
+				ratio = newHeight / (windowHeight - upperBound);
 
-			if (newHeight > windowHeight - $('#header-menu').height() - (windowHeight / 15)) {
+			if (ratio >= 1 - snapMargin) {
 				snapToTop = true;
 			} else {
 				snapToTop = false;
 			}
+
+			resizeSavePosition(ratio);
 
 			toggleMaximize(e);
 		}
 
 		function toggleMaximize(e) {
 			if (e.clientY - resizeDown === 0 || snapToTop) {
-				var newPercentage = getMaximumPercentage();
+				var newPercentage = 1;
 
 				if (!postContainer.hasClass('maximized') || !snapToTop) {
 					oldPercentage = postContainer.percentage;
-					doResize(postContainer, newPercentage);
+					resizeIt(postContainer, newPercentage);
 					postContainer.addClass('maximized');
 				} else {
-					doResize(postContainer, oldPercentage);
+					resizeIt(postContainer, (oldPercentage >= 1 - snapMargin) ? 0.5 : oldPercentage);
 					postContainer.removeClass('maximized');
 				}
 			}
@@ -128,12 +163,14 @@ define('composer/resize', ['autosize'], function(autosize) {
 		function resizeAction(e) {
 			if (resizeActive) {
 				var position = (e.clientY - resizeOffset),
-					newHeight = $(window).height() - position;
+					windowHeight = $window.height(),
+					upperBound = getUpperBound(),
+					newHeight = windowHeight - position,
+					ratio = newHeight / (windowHeight - upperBound);
 
-				doResize(postContainer, newHeight / $(window).height());
+				resizeIt(postContainer, ratio);
 
 				resizeWritePreview(postContainer);
-				resizeSavePosition(newHeight);
 
 				if (Math.abs(e.clientY - resizeDown) > 0) {
 					postContainer.removeClass('maximized');
@@ -144,16 +181,14 @@ define('composer/resize', ['autosize'], function(autosize) {
 			return false;
 		}
 
-		function resizeSavePosition(px) {
-			var	percentage = px / $(window).height(),
-				max = getMaximumPercentage();
-			localStorage.setItem('composer:resizePercentage', percentage < max ? percentage : max);
+		function resizeSavePosition(percentage) {
+			localStorage.setItem('composer:resizePercentage', percentage <= 1 ? percentage : 1);
 		}
 
 		var	resizeActive = false,
 			resizeOffset = 0,
-            resizeDown = 0,
-            snapToTop = false,
+			resizeDown = 0,
+			snapToTop = false,
 			resizeEl = postContainer.find('.resizer');
 
 		resizeEl
@@ -168,19 +203,19 @@ define('composer/resize', ['autosize'], function(autosize) {
 			});
 	};
 
-	function getMaximumPercentage() {
-		return ($(window).height() - $('#header-menu').height() - 1) / $(window).height();
+	function getUpperBound() {
+		return $headerMenu.height() + 1;
 	}
 
 	function resizeWritePreview(postContainer) {
 		var total = getFormattingHeight(postContainer),
-			containerHeight = postContainer.percentage * $(window).height() - $('#header-menu').height() - total;
+			containerHeight = postContainer.height() + 20 - total;
 
 		postContainer
 			.find('.write-preview-container')
 			.css('height', containerHeight);
 
-		$(window).trigger('action:composer.resize', {
+		$window.trigger('action:composer.resize', {
 			formattingHeight: total,
 			containerHeight: containerHeight
 		});

--- a/static/templates/composer.tpl
+++ b/static/templates/composer.tpl
@@ -1,6 +1,5 @@
 <div class="composer">
-
-	<div class="composer-container">
+	<div class="composer-container <!-- IF isTopicOrMain -->topic-main<!-- ENDIF isTopicOrMain -->">
 		<nav class="navbar navbar-fixed-top mobile-navbar visible-xs visible-sm">
 			<span class="pull-left">
 				<button class="btn btn-primary composer-discard" data-action="discard" tabindex="-1"><i class="fa fa-times"></i></button>
@@ -8,6 +7,9 @@
 			<span class="pull-right">
 				<button class="btn btn-primary composer-submit" data-action="post" tabindex="-1"><i class="fa fa-chevron-right"></i></button>
 			</span>
+			<!-- IF !isTopicOrMain -->
+			<h3 class="title">[[topic:composer.replying_to, "{title}"]]</h3>
+			<!-- ENDIF !isTopicOrMain -->
 		</nav>
 		<div class="title-container row">
 			<!-- IF showHandleInput -->
@@ -18,7 +20,7 @@
 				<!-- IF isTopicOrMain -->
 				<input class="title form-control" type="text" tabindex="1" placeholder="[[topic:composer.title_placeholder]]" value="{title}"/>
 				<!-- ELSE -->
-				<span class="title form-control">[[topic:composer.replying_to, "{title}"]]</span>
+				<span class="title form-control hidden-xs hidden-sm">[[topic:composer.replying_to, "{title}"]]</span>
 				<!-- ENDIF isTopicOrMain -->
 			</div>
 			<!-- ELSE -->
@@ -26,7 +28,7 @@
 				<!-- IF isTopicOrMain -->
 				<input class="title form-control" type="text" tabindex="1" placeholder="[[topic:composer.title_placeholder]]" value="{title}"/>
 				<!-- ELSE -->
-				<span class="title form-control">[[topic:composer.replying_to, "{title}"]]</span>
+				<span class="title form-control hidden-xs hidden-sm">[[topic:composer.replying_to, "{title}"]]</span>
 				<!-- ENDIF isTopicOrMain -->
 			</div>
 			<!-- IF isTopic -->


### PR DESCRIPTION
Contains everything from `patch2` and `patch1` branches, but changes the `resizeWritePreview` JavaScript operation to a CSS rule
- CSS controls positioning of `.write-preview-container`, which makes the dragging animation even more fluid
- Use direct DOM methods instead of jQuery for most CSS changes, which also improves perf
- Move title to `navbar` on mobile when not main post to save screen real estate

There's also NodeBB/NodeBB#3807 which offers an alternative way of getting the Bootstrap environment, and could drastically improve perf