### PR TITLE
Let's try this with CSS

### DIFF
--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -1,112 +1,127 @@
-@topbarHeight: 50px;
+@topbarHeight: 51px;
 
-html.composing {
 
-	@media (max-width: @screen-sm-max) {
+@formattingRowHeight: 62px;
+@titleContainerRowHeight: 47px;
+@categorySelectHeight: 42px;
+@tagsContainerHeight: 36px;
+
+
+@media (max-width: @screen-sm-max), (max-height: 480px) {
+	html.composing {
+
+		@mobileNavHeight: 51px;
+		@formattingRowHeight: 52px;
+
 		& {
 			overflow: hidden;
 		}
 
+		.resizer {
+			visibility: hidden;
+		}
+
+		body {
+			height: 0 !important;
+		}
+
 		.composer {
+			padding: 0;
+			width: 100%;
+			background: rgba(224, 224, 224, 1);
 			position: absolute;
 			box-shadow: none;
 			top: 0 !important;
-		}
 
-		.composer-container {
-			.write {
-				padding-bottom: 25px;
-			}
+			.composer-container {
+				overflow-y: visible;
+				overflow-x: hidden;
+				padding: 0;
+				padding-top: 50px;
+				height: 100%;
+				background: white;
 
-			.write-preview-container {
-				left: 0;
-				right: 0;
-				height: auto;
-				bottom: 0;
-				overflow: scroll;
+				.write {
+					padding-bottom: 25px;
+			    overflow-y: scroll;
+			    height: 100%;
+				}
 
-				top: 103px;
-			}
-
-			&.topic-main {
 				.write-preview-container {
-					top: 226px;
+					left: 0;
+					right: 0;
+					height: auto;
+					bottom: 0;
+					overflow: hidden;
+
+					top: (@mobileNavHeight + @formattingRowHeight);
+				}
+
+				&.topic-main {
+					.write-preview-container {
+						top: (@mobileNavHeight + @formattingRowHeight +
+							@titleContainerRowHeight + @categorySelectHeight);
+					}
+				}
+			}
+
+			.title-container {
+				margin: 0;
+				padding: 0;
+
+				.title {
+					padding-left: 8px;
+					white-space: nowrap;
+					overflow: hidden;
+					text-overflow: ellipsis;
+					width: 100%;
+				}
+			}
+
+			.write, .preview {
+				border-bottom: 0;
+				min-height: 100%;
+				outline: none;
+				padding: 25px 10px;
+				margin-bottom: 0px;
+				padding-bottom: 0px;
+				font-size: 18px;
+			}
+
+			.form-control {
+				box-shadow: none;
+			}
+
+			.formatting-bar {
+				margin: 0;
+				padding: 0;
+			}
+
+			.mobile-navbar {
+				background: @btn-primary-bg;
+				color: @btn-primary-color;
+				position: absolute;
+
+				button {
+					font-size: 20px;
+				}
+
+				.title {
+					margin: 0px;
+					line-height: 50px;
+					padding: 0px 10px;
+					white-space: nowrap;
+					overflow: hidden;
+					text-overflow: ellipsis;
+					font-size: 22px;
+					font-weight: normal;
 				}
 			}
 		}
-	}
 
-	body {
-		height: 0px !important;
-	}
-
-	.composer {
-		padding: 0;
-
-		.composer-container {
-			overflow-y: visible;
-			overflow-x: hidden;
-			padding: 0;
-			padding-top: 50px;
-			height: 100%;
-			background: white;
-		}
-
-		.title-container {
-			margin-top: 0px;
-
-			.title {
-				padding-left: 8px;
-				white-space: nowrap;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				width: 100%;
-			}
-		}
-
-		.write, .preview {
-			border-bottom: 0;
-			min-height: 100%;
-			outline: none;
-			padding: 25px 10px;
-			margin-bottom: 0px;
-			padding-bottom: 0px;
-			font-size: 18px;
-		}
-
-		.form-control {
-			box-shadow: none;
-		}
-
-		.formatting-bar {
-			margin: 0;
+		.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
 			padding: 0;
 		}
-
-		.mobile-navbar {
-			background: @btn-primary-bg;
-			color: @btn-primary-color;
-			position: absolute;
-
-			button {
-				font-size: 20px;
-			}
-
-			.title {
-				margin: 0px;
-				line-height: 50px;
-				padding: 0px 10px;
-				white-space: nowrap;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				font-size: 22px;
-				font-weight: normal;
-			}
-		}
-	}
-
-	.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
-		padding: 0;
 	}
 }
 
@@ -132,6 +147,19 @@ html.composing {
 		min-height: 50px;
 		padding-left: 10px;
 		padding-right: 10px;
+
+		&.topic-main {
+			.write-preview-container {
+				top: (@formattingRowHeight + @titleContainerRowHeight +
+					@categorySelectHeight + 35px);
+			}
+
+			@media (min-width: @screen-lg-min) {
+				.write-preview-container {
+					top: (@formattingRowHeight + @titleContainerRowHeight + 35px);
+				}
+			}
+		}
 	}
 
 	.title-container {
@@ -165,8 +193,9 @@ html.composing {
 				box-shadow: none;
 
 				input {
-					height:28px;
+					height: 28px;
 					padding: 4px 6px;
+					max-width: 25em;
 				}
 
 				.label {
@@ -178,8 +207,7 @@ html.composing {
 	}
 
 	.write-preview-container {
-		// height: 100%;
-		margin: 0 0;
+		margin: 0;
 		min-height: 200px;
 
 		position: absolute;
@@ -187,11 +215,7 @@ html.composing {
 		right: 10px;
 		height: auto;
 		bottom: 80px;
-		top: 140px;
-
-		@media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
-			top: 217px;
-		}
+		top: (@formattingRowHeight + @titleContainerRowHeight + 35px);
 
 		> div {
 			height: 100%;
@@ -210,9 +234,9 @@ html.composing {
 		height: 100%;
 		margin: 0 auto;
 		font-size: 14px;
-		-webkit-border-radius: 0px;
-		-moz-border-radius: 0px;
-		border-radius: 0px;
+		-webkit-border-radius: 0;
+		-moz-border-radius: 0;
+		border-radius: 0;
 		resize: none;
 		overflow: auto;
 		padding: 20px;
@@ -314,6 +338,7 @@ html.composing {
 			}
 		}
 
+		top: @topbarHeight !important;
 		box-shadow: none;
 	}
 
@@ -345,22 +370,11 @@ html.composing {
 		width: auto;
 		height: auto;
 		max-width: 100px;
-		max-height: 100px
+		max-height: 100px;
 	}
 
 	.topic-thumb-ctrl.form-group {
 		display: inline-block;
 		vertical-align: -50% !important;
-	}
-}
-
-@media (max-width: 767px), (max-height: 480px) {
-	.composer {
-		width: 100%;
-		background: rgba(224, 224, 224, 1);
-	}
-
-	.resizer {
-		visibility: hidden;
 	}
 }

--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -178,7 +178,7 @@ html.composing {
 	}
 
 	.write-preview-container {
-		height: 100%;
+		// height: 100%;
 		margin: 0 0;
 		min-height: 200px;
 
@@ -194,7 +194,7 @@ html.composing {
 		}
 
 		> div {
-			height:100%;
+			height: 100%;
 		}
 	}
 

--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -1,13 +1,38 @@
 @topbarHeight: 50px;
 
-
 html.composing {
-	&.mobile {
-		overflow: hidden;
+
+	@media (max-width: @screen-sm-max) {
+		& {
+			overflow: hidden;
+		}
 
 		.composer {
 			position: absolute;
 			box-shadow: none;
+			top: 0 !important;
+		}
+
+		.composer-container {
+			.write {
+				padding-bottom: 25px;
+			}
+
+			.write-preview-container {
+				left: 0;
+				right: 0;
+				height: auto;
+				bottom: 0;
+				overflow: scroll;
+
+				top: 103px;
+			}
+
+			&.topic-main {
+				.write-preview-container {
+					top: 226px;
+				}
+			}
 		}
 	}
 
@@ -66,6 +91,17 @@ html.composing {
 			button {
 				font-size: 20px;
 			}
+
+			.title {
+				margin: 0px;
+				line-height: 50px;
+				padding: 0px 10px;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				font-size: 22px;
+				font-weight: normal;
+			}
 		}
 	}
 
@@ -79,7 +115,7 @@ html.composing {
 
 	position: fixed;
 	bottom: 0;
-	top: 50%;
+	top: 0;
 	right: 0;
 	left: 0;
 
@@ -142,9 +178,20 @@ html.composing {
 	}
 
 	.write-preview-container {
-		height:100%;
+		height: 100%;
 		margin: 0 0;
 		min-height: 200px;
+
+		position: absolute;
+		left: 10px;
+		right: 10px;
+		height: auto;
+		bottom: 80px;
+		top: 140px;
+
+		@media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+			top: 217px;
+		}
 
 		> div {
 			height:100%;
@@ -157,7 +204,7 @@ html.composing {
 		.box-shadow(inset 0px 1px 1px rgba(0, 0, 0, 0.05));
 	}
 
-	.write, .preview  {
+	.write, .preview {
 		display: block;
 		width: 100%;
 		height: 100%;
@@ -166,7 +213,7 @@ html.composing {
 		-webkit-border-radius: 0px;
 		-moz-border-radius: 0px;
 		border-radius: 0px;
-		resize:none;
+		resize: none;
 		overflow: auto;
 		padding: 20px;
 	}
@@ -280,31 +327,31 @@ html.composing {
 		display: none;
 	}
 
-  .topic-thumb-container {
-    margin-top: 5px;
-    margin-left: 8px;
-    margin-right: 8px;
-    background: rgb(255, 255, 255);
-    background: rgba(255, 255, 255, 0.6);
-    padding: 10px;
-  }
+	.topic-thumb-container {
+		margin-top: 5px;
+		margin-left: 8px;
+		margin-right: 8px;
+		background: rgb(255, 255, 255);
+		background: rgba(255, 255, 255, 0.6);
+		padding: 10px;
+	}
 
-  .topic-thumb-btn {
-    cursor: hand;
-    cursor: pointer;
-  }
+	.topic-thumb-btn {
+		cursor: hand;
+		cursor: pointer;
+	}
 
-  .topic-thumb-preview {
-    width: auto;
-    height: auto;
-    max-width: 100px;
-    max-height: 100px
-  }
+	.topic-thumb-preview {
+		width: auto;
+		height: auto;
+		max-width: 100px;
+		max-height: 100px
+	}
 
-  .topic-thumb-ctrl.form-group {
-    display: inline-block;
-    vertical-align: -50% !important;
-  }
+	.topic-thumb-ctrl.form-group {
+		display: inline-block;
+		vertical-align: -50% !important;
+	}
 }
 
 @media (max-width: 767px), (max-height: 480px) {

--- a/static/lib/composer/resize.js
+++ b/static/lib/composer/resize.js
@@ -3,7 +3,7 @@
 
 /* globals app, define, config, utils*/
 
-define('composer/resize', ['autosize'], function(autosize) {
+define('composer/resize', function () {
 	var resize = {},
 		oldPercentage = 0,
 		minimumPercentage = 0.3,
@@ -26,10 +26,8 @@ define('composer/resize', ['autosize'], function(autosize) {
 
 	function doResize(postContainer, percentage, realPercentage) {
 
-		if (window.innerWidth < 768 || window.innerHeight < 480) {
+		if (window.innerWidth < 992 || window.innerHeight < 480) {
 			$html.addClass('composing mobile');
-			autosize(postContainer.find('textarea')[0]);
-			percentage = 1;
 		} else {
 			$html[0].className = $html[0].className.replace('composing mobile', '');
 
@@ -48,7 +46,7 @@ define('composer/resize', ['autosize'], function(autosize) {
 					upperBound = getUpperBound();
 					realPercentage = top = percentage * (windowHeight - upperBound) / windowHeight;
 				}
-				top = (Math.abs(1-top) * 100) + '%';
+				top = (Math.abs(1 - top) * 100) + '%';
 
 				postContainer[0].style.top = top;
 
@@ -134,13 +132,15 @@ define('composer/resize', ['autosize'], function(autosize) {
 				var newPercentage = 1;
 
 				if (!postContainer.hasClass('maximized') || !snapToTop) {
+					resizeSavePosition(postContainer.percentage);
 					oldPercentage = postContainer.percentage;
-					resizeIt(postContainer, newPercentage);
 					postContainer.addClass('maximized');
 				} else {
-					resizeIt(postContainer, (oldPercentage >= 1 - snapMargin) ? 0.5 : oldPercentage);
+					newPercentage = (oldPercentage && (oldPercentage < 1 - snapMargin)) ? oldPercentage : 0.5;
+					resizeIt(postContainer, newPercentage);
 					postContainer.removeClass('maximized');
 				}
+				postContainer.percentage = newPercentage;
 			}
 		}
 

--- a/static/lib/composer/resize.js
+++ b/static/lib/composer/resize.js
@@ -25,7 +25,7 @@ define('composer/resize', ['autosize'], function(autosize) {
 		doResize(postContainer, percentage);
 	};
 
-	function doResize(postContainer, percentage) {
+	function doResize(postContainer, percentage, realPercentage) {
 		var env = utils.findBootstrapEnvironment();
 
 
@@ -54,8 +54,14 @@ define('composer/resize', ['autosize'], function(autosize) {
 			}
 
 			if (env === 'md' || env === 'lg') {
-				var top = percentage * (windowHeight - upperBound) / windowHeight;
+				var top;
+				if (realPercentage) {
+					top = realPercentage;
+				} else {
+					top = percentage * (windowHeight - upperBound) / windowHeight;
+				}
 				top = (Math.abs(1-top) * 100) + '%';
+
 				postContainer.css({
 					'top': top
 				});
@@ -79,7 +85,7 @@ define('composer/resize', ['autosize'], function(autosize) {
 		postContainer.css('visibility', 'visible');
 
 		// Add some extra space at the bottom of the body so that the user can still scroll to the last post w/ composer open
-		$body.css({ 'margin-bottom': postContainer.outerHeight() });
+		$body.css({ 'margin-bottom': postContainer.height() + 20 });
 
 		resizeWritePreview(postContainer);
 	}
@@ -166,7 +172,7 @@ define('composer/resize', ['autosize'], function(autosize) {
 					newHeight = windowHeight - position,
 					ratio = newHeight / (windowHeight - upperBound);
 
-				resizeIt(postContainer, ratio);
+				resizeIt(postContainer, ratio, newHeight / windowHeight);
 
 				resizeWritePreview(postContainer);
 
@@ -206,30 +212,20 @@ define('composer/resize', ['autosize'], function(autosize) {
 	}
 
 	function resizeWritePreview(postContainer) {
-		var total = getFormattingHeight(postContainer),
-			containerHeight = postContainer.height() + 20 - total;
+		var container = postContainer
+			.find('.write-preview-container');
+		var contBox = container[0].getBoundingClientRect();
+		var outerBox = container.parent().parent()[0].getBoundingClientRect();
 
-		postContainer
-			.find('.write-preview-container')
-			.css('height', containerHeight);
+		var newHeight = (contBox.bottom - contBox.top) +
+			(outerBox.bottom - 30 - contBox.bottom );
+
+		container.css('height', newHeight);
 
 		$window.trigger('action:composer.resize', {
-			formattingHeight: total,
-			containerHeight: containerHeight
+			containerHeight: newHeight
 		});
 	}
-
-	function getFormattingHeight(postContainer) {
-		return [
-			postContainer.find('.title-container').outerHeight(true),
-			postContainer.find('.formatting-bar').outerHeight(true),
-			postContainer.find('.topic-thumb-container').outerHeight(true),
-			$('.taskbar').height()
-		].reduce(function(a, b) {
-			return a + b;
-		});
-	}
-
 
 	return resize;
 });

--- a/static/lib/composer/resize.js
+++ b/static/lib/composer/resize.js
@@ -14,7 +14,6 @@ define('composer/resize', ['autosize'], function(autosize) {
 		$window = $(window),
 		$headerMenu = $('#header-menu');
 
-
 	resize.reposition = function(postContainer) {
 		var	percentage = localStorage.getItem('composer:resizePercentage') || 0.5;
 
@@ -40,20 +39,18 @@ define('composer/resize', ['autosize'], function(autosize) {
 			percentage = 1;
 		} else {
 			$html.removeClass('composing mobile');
-		}
 
-		if (percentage) {
-			var upperBound = getUpperBound();
+			if (percentage) {
+				var upperBound = getUpperBound();
 
-			var windowHeight = $window.height();
+				var windowHeight = window.innerHeight;
 
-			if (percentage < minimumPercentage) {
-				percentage = minimumPercentage;
-			} else if (percentage >= 1) {
-				percentage = 1;
-			}
+				if (percentage < minimumPercentage) {
+					percentage = minimumPercentage;
+				} else if (percentage >= 1) {
+					percentage = 1;
+				}
 
-			if (env === 'md' || env === 'lg') {
 				var top;
 				if (realPercentage) {
 					top = realPercentage;
@@ -62,12 +59,12 @@ define('composer/resize', ['autosize'], function(autosize) {
 				}
 				top = (Math.abs(1-top) * 100) + '%';
 
-				postContainer.css({
-					'top': top
-				});
-			} else {
-				postContainer.removeAttr('style');
+				postContainer[0].style.top = top;
+
+				// Add some extra space at the bottom of the body so that the user can still scroll to the last post w/ composer open
+				$body[0].style.marginBottom = postContainer.height() + 20 + 'px';
 			}
+
 		}
 
 		postContainer.percentage = percentage;
@@ -82,12 +79,9 @@ define('composer/resize', ['autosize'], function(autosize) {
 			postContainer.find('#files.lt-ie9').removeClass('hide');
 		}
 
-		postContainer.css('visibility', 'visible');
+		postContainer[0].style.visibility = 'visible';
 
-		// Add some extra space at the bottom of the body so that the user can still scroll to the last post w/ composer open
-		$body.css({ 'margin-bottom': postContainer.height() + 20 });
-
-		resizeWritePreview(postContainer);
+		$window.trigger('action:composer.resize');
 	}
 
 	var resizeIt = doResize;
@@ -128,18 +122,18 @@ define('composer/resize', ['autosize'], function(autosize) {
 			$body.off('touchmove', resizeTouchAction);
 
 			var position = (e.clientY - resizeOffset),
-				windowHeight = $window.height(),
+				windowHeight = window.innerHeight,
 				upperBound = getUpperBound(),
 				newHeight = windowHeight - position,
-				ratio = newHeight / (windowHeight - upperBound);
+				percentage = newHeight / (windowHeight - upperBound);
 
-			if (ratio >= 1 - snapMargin) {
+			if (percentage >= 1 - snapMargin) {
 				snapToTop = true;
 			} else {
 				snapToTop = false;
 			}
 
-			resizeSavePosition(ratio);
+			resizeSavePosition(percentage);
 
 			toggleMaximize(e);
 		}
@@ -167,14 +161,12 @@ define('composer/resize', ['autosize'], function(autosize) {
 		function resizeAction(e) {
 			if (resizeActive) {
 				var position = (e.clientY - resizeOffset),
-					windowHeight = $window.height(),
+					windowHeight = window.innerHeight,
 					upperBound = getUpperBound(),
 					newHeight = windowHeight - position,
-					ratio = newHeight / (windowHeight - upperBound);
+					percentage = newHeight / (windowHeight - upperBound);
 
-				resizeIt(postContainer, ratio, newHeight / windowHeight);
-
-				resizeWritePreview(postContainer);
+				resizeIt(postContainer, percentage, newHeight / windowHeight);
 
 				if (Math.abs(e.clientY - resizeDown) > 0) {
 					postContainer.removeClass('maximized');
@@ -208,23 +200,7 @@ define('composer/resize', ['autosize'], function(autosize) {
 	};
 
 	function getUpperBound() {
-		return $headerMenu.height() + 1;
-	}
-
-	function resizeWritePreview(postContainer) {
-		var container = postContainer
-			.find('.write-preview-container');
-		var contBox = container[0].getBoundingClientRect();
-		var outerBox = container.parent().parent()[0].getBoundingClientRect();
-
-		var newHeight = (contBox.bottom - contBox.top) +
-			(outerBox.bottom - 30 - contBox.bottom );
-
-		container.css('height', newHeight);
-
-		$window.trigger('action:composer.resize', {
-			containerHeight: newHeight
-		});
+		return $headerMenu[0].getBoundingClientRect().bottom;
 	}
 
 	return resize;

--- a/static/lib/composer/resize.js
+++ b/static/lib/composer/resize.js
@@ -25,25 +25,16 @@ define('composer/resize', ['autosize'], function(autosize) {
 	};
 
 	function doResize(postContainer, percentage, realPercentage) {
-		var env = utils.findBootstrapEnvironment();
 
-
-		// todo, lump in browsers that don't support transform (ie8) here
-		// at this point we should use modernizr
-
-		// done, just use `top` instead of `translate`
-
-		if (env === 'sm' || env === 'xs' || window.innerHeight < 480) {
+		if (window.innerWidth < 768 || window.innerHeight < 480) {
 			$html.addClass('composing mobile');
 			autosize(postContainer.find('textarea')[0]);
 			percentage = 1;
 		} else {
-			$html.removeClass('composing mobile');
+			$html[0].className = $html[0].className.replace('composing mobile', '');
 
 			if (percentage) {
-				var upperBound = getUpperBound();
-
-				var windowHeight = window.innerHeight;
+				var upperBound, top, windowHeight = window.innerHeight;
 
 				if (percentage < minimumPercentage) {
 					percentage = minimumPercentage;
@@ -51,18 +42,18 @@ define('composer/resize', ['autosize'], function(autosize) {
 					percentage = 1;
 				}
 
-				var top;
 				if (realPercentage) {
 					top = realPercentage;
 				} else {
-					top = percentage * (windowHeight - upperBound) / windowHeight;
+					upperBound = getUpperBound();
+					realPercentage = top = percentage * (windowHeight - upperBound) / windowHeight;
 				}
 				top = (Math.abs(1-top) * 100) + '%';
 
 				postContainer[0].style.top = top;
 
 				// Add some extra space at the bottom of the body so that the user can still scroll to the last post w/ composer open
-				$body[0].style.marginBottom = postContainer.height() + 20 + 'px';
+				$body[0].style.marginBottom = (realPercentage * windowHeight + 20) + 'px';
 			}
 
 		}
@@ -91,9 +82,9 @@ define('composer/resize', ['autosize'], function(autosize) {
 					window.mozRequestAnimationFrame;
 
 	if (raf) {
-		resizeIt = function(postContainer, percentage) {
+		resizeIt = function(postContainer, percentage, realPercentage) {
 			raf(function() {
-				doResize(postContainer, percentage);
+				doResize(postContainer, percentage, realPercentage);
 			});
 		};
 	}
@@ -163,7 +154,7 @@ define('composer/resize', ['autosize'], function(autosize) {
 				var position = (e.clientY - resizeOffset),
 					windowHeight = window.innerHeight,
 					upperBound = getUpperBound(),
-					newHeight = windowHeight - position,
+					newHeight = windowHeight - (position > upperBound ? position : upperBound),
 					percentage = newHeight / (windowHeight - upperBound);
 
 				resizeIt(postContainer, percentage, newHeight / windowHeight);

--- a/static/templates/composer.tpl
+++ b/static/templates/composer.tpl
@@ -1,6 +1,5 @@
 <div class="composer">
-
-	<div class="composer-container">
+	<div class="composer-container <!-- IF isTopicOrMain -->topic-main<!-- ENDIF isTopicOrMain -->">
 		<nav class="navbar navbar-fixed-top mobile-navbar visible-xs visible-sm">
 			<span class="pull-left">
 				<button class="btn btn-primary composer-discard" data-action="discard" tabindex="-1"><i class="fa fa-times"></i></button>
@@ -8,6 +7,9 @@
 			<span class="pull-right">
 				<button class="btn btn-primary composer-submit" data-action="post" tabindex="-1"><i class="fa fa-chevron-right"></i></button>
 			</span>
+			<!-- IF !isTopicOrMain -->
+			<h3 class="title">[[topic:composer.replying_to, "{title}"]]</h3>
+			<!-- ENDIF !isTopicOrMain -->
 		</nav>
 		<div class="title-container row">
 			<!-- IF showHandleInput -->
@@ -18,7 +20,7 @@
 				<!-- IF isTopicOrMain -->
 				<input class="title form-control" type="text" tabindex="1" placeholder="[[topic:composer.title_placeholder]]" value="{title}"/>
 				<!-- ELSE -->
-				<span class="title form-control">[[topic:composer.replying_to, "{title}"]]</span>
+				<span class="title form-control hidden-xs hidden-sm">[[topic:composer.replying_to, "{title}"]]</span>
 				<!-- ENDIF isTopicOrMain -->
 			</div>
 			<!-- ELSE -->
@@ -26,7 +28,7 @@
 				<!-- IF isTopicOrMain -->
 				<input class="title form-control" type="text" tabindex="1" placeholder="[[topic:composer.title_placeholder]]" value="{title}"/>
 				<!-- ELSE -->
-				<span class="title form-control">[[topic:composer.replying_to, "{title}"]]</span>
+				<span class="title form-control hidden-xs hidden-sm">[[topic:composer.replying_to, "{title}"]]</span>
 				<!-- ENDIF isTopicOrMain -->
 			</div>
 			<!-- IF isTopic -->


### PR DESCRIPTION
@julianlam This is the *other* PR with more changes, including using CSS to do most of the stuff instead of JS. There are also a few changes on mobile, like hiding the tags input (it's hard to use on mobile anyways) and showing the formatting stuff always. Also, removed the use of `autosize` on the `textarea` by making the textarea scroll instead of the container.