### PR TITLE
fix for write-preview-container height calc

### DIFF
--- a/static/lib/composer/resize.js
+++ b/static/lib/composer/resize.js
@@ -224,7 +224,7 @@ define('composer/resize', ['autosize'], function(autosize) {
 			postContainer.find('.title-container').outerHeight(true),
 			postContainer.find('.formatting-bar').outerHeight(true),
 			postContainer.find('.topic-thumb-container').outerHeight(true),
-			$('.taskbar').height()
+			$('.taskbar').height() || 50
 		].reduce(function(a, b) {
 			return a + b;
 		});


### PR DESCRIPTION
When using a theme that does not have the taskbar, the composer's write-preview-container height is not calculated properly and the composer goes out of the window bounds.

https://github.com/pichalite/nodebb-theme-material/issues/17 