### PR TITLE
Add element to autocomplete event data

### DIFF
--- a/static/lib/composer/autocomplete.js
+++ b/static/lib/composer/autocomplete.js
@@ -7,7 +7,9 @@ define('composer/autocomplete', function() {
 	var autocomplete = {};
 
 	autocomplete.init = function(postContainer) {
+		var element = postContainer.find('.write');
 		var data = {
+			element: element,
 			strategies: [],
 			options: {
 				zIndex: 20000,
@@ -20,7 +22,7 @@ define('composer/autocomplete', function() {
 		};
 
 		$(window).trigger('composer:autocomplete:init', data);
-		postContainer.find('.write').textcomplete(data.strategies, data.options);
+		data.element.textcomplete(data.strategies, data.options);
 		$('.textcomplete-wrapper').css('height', '100%').find('textarea').css('height', '100%');
 	};
 


### PR DESCRIPTION
The problem with not passing the element for me:
I use an async socket call to fetch some information being used for the definition of the strategy.
So in case the event gets triggered before the socket call has been finished the strategy cannot be added.