### PR TITLE
Fix quote attribution for topic titles that include [ or ]

### DIFF
--- a/static/lib/composer.js
+++ b/static/lib/composer.js
@@ -173,6 +173,10 @@ define('composer', [
 	composer.addQuote = function(tid, topicSlug, postIndex, pid, title, username, text, uuid) {
 		uuid = uuid || composer.active;
 
+		if (topicSlug) {
+			topicSlug = topicSlug.replace('[', '&#91;').replace(']', '&#93;');
+		}
+
 		if (text) {
 			text = '> ' + text.replace(/\n/g, '\n> ') + '\n\n';
 		}

--- a/static/lib/composer.js
+++ b/static/lib/composer.js
@@ -173,8 +173,8 @@ define('composer', [
 	composer.addQuote = function(tid, topicSlug, postIndex, pid, title, username, text, uuid) {
 		uuid = uuid || composer.active;
 
-		if (topicSlug) {
-			topicSlug = topicSlug.replace('[', '&#91;').replace(']', '&#93;');
+		if (title) {
+			title = title.replace('[', '&#91;').replace(']', '&#93;');
 		}
 
 		if (text) {

--- a/static/lib/composer.js
+++ b/static/lib/composer.js
@@ -174,7 +174,7 @@ define('composer', [
 		uuid = uuid || composer.active;
 
 		if (title) {
-			title = title.replace('[', '&#91;').replace(']', '&#93;');
+			title = title.replace(/\[/g, '&#91;').replace(/\]/g, '&#93;');
 		}
 
 		if (text) {


### PR DESCRIPTION
Specifically, a `[` at the start of the title or a `]` at the end of a title, as it would otherwise interfere with either the Markdown parsing or the translation system