### PR TITLE
use flex on mobile

### DIFF
--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -13,6 +13,26 @@
 html.composing {
 	&.mobile {
 		overflow: hidden;
+
+		.composer {
+			.composer-container {
+				display: flex;
+				flex-direction: column;
+			}
+
+			.write, .preview {
+				min-height: auto;
+				flex-grow: 1;
+				height: auto !important;
+			}
+
+			.write-preview-container, .write-preview-container > div {
+				min-height: auto;
+				flex-grow: 1;
+				height: auto !important;
+				display: flex;
+			}
+		}
 	}
 
 	body {


### PR DESCRIPTION
This makes the textarea have the only scrollbar on the page and stops the tags bar from going through the textarea.

https://what.thedailywtf.com/topic/19512/tag-entry-on-mobile

![](https://what.thedailywtf.com/uploads/files/1459176363568-screenshot_2016-03-28-15-47-32.png)