### PR TITLE
fix pasting images copied from Google Chrome 48+

### DIFF
--- a/static/lib/composer/uploads.js
+++ b/static/lib/composer/uploads.js
@@ -169,28 +169,32 @@ define('composer/uploads', [
 	function initializePaste(post_uuid) {
 		$(window).off('paste').on('paste', function(event) {
 
-			var items = (event.clipboardData || event.originalEvent.clipboardData || {}).items,
-				fd;
+			var items = (event.clipboardData || event.originalEvent.clipboardData || {}).items;
 
-			if(items && items.length) {
+			[].some.call(items, function(item) {
+				var blob = item.getAsFile();
 
-				var blob = items[0].getAsFile();
-				if(blob) {
-					blob.name = 'upload-' + utils.generateUUID();
-
-					if (window.FormData) {
-						fd = new FormData();
-						fd.append('files[]', blob, blob.name);
-					}
-
-					uploadContentFiles({
-						files: [blob],
-						post_uuid: post_uuid,
-						route: '/api/post/upload',
-						formData: fd
-					});
+				if (!blob) {
+					return false;
 				}
-			}
+
+				blob.name = 'upload-' + utils.generateUUID();
+
+				var fd = null;
+				if (window.FormData) {
+					fd = new FormData();
+					fd.append('files[]', blob, blob.name);
+				}
+
+				uploadContentFiles({
+					files: [blob],
+					post_uuid: post_uuid,
+					route: '/api/post/upload',
+					formData: fd
+				});
+
+				return true;
+			});
 		});
 	}
 


### PR DESCRIPTION
Images get copied to the clipboard as a `text/html` document as well as an `image/png`. NodeBB only looks at the `text/html` and bails.