### PR TITLE
Bugfix/hidden buttons

### DIFF
--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -268,7 +268,7 @@ html.composing {
 		min-height: 200px;
 
 		> div {
-			height:100%;
+			height: 100%;
 		}
 	}
 

--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -354,6 +354,8 @@ html.composing {
 		}
 
 		.formatting-group {
+			overflow-x: scroll;
+			white-space: nowrap;
 			display: inline-block;
 			list-style: none;
 			padding: 0;
@@ -460,6 +462,12 @@ html.composing {
 	.composer {
 		width: 100%;
 		padding-top: 0;
+		.formatting-bar {
+			.formatting-group {
+				display: block;
+			}
+
+		}
 	}
 
 	.resizer {

--- a/static/less/page-compose.less
+++ b/static/less/page-compose.less
@@ -26,9 +26,7 @@ body.page-compose {
 	}
 
 	.write-preview-container {
-		height: auto !important;
-		position: absolute;
-		top: 110px;
+		height: 65vh;
 		bottom: 0;
 		right: 0;
 		left: 0;


### PR DESCRIPTION
This PR addresses some critical issues where when using a separate route for the composer, the Submit / Discard buttons are blocked by the textarea. This fix includes making the composer formatting buttons overflow / scroll like the non-separate route behaves. Fixes #69 

~~I cringed a little making the viewport 480px~~ I found a better way to resize the textarea window, and it's not perfect, but this setting is a decent compromise for a responsive separate-route composer. Maybe @pichalite can give some insight on how to make this more elegant. 