### PR TITLE
Don't override the default setPosition method with a broken one.

### DIFF
--- a/static/lib/composer/autocomplete.js
+++ b/static/lib/composer/autocomplete.js
@@ -12,12 +12,7 @@ define('composer/autocomplete', ['composer/preview'], function(preview) {
 			element: element,
 			strategies: [],
 			options: {
-				zIndex: 20000,
-				listPosition: function(position) {
-					this.$el.css(this._applyPlacement(position));
-					this.$el.css('position', 'fixed');
-					return this;
-				}
+				zIndex: 20000
 			}
 		};
 


### PR DESCRIPTION
The default sets the position correctly when the page is scrolled and there's a position: fixed element as an ancestor of the input.