### PR TITLE
Set title text for taskbar

### DIFF
--- a/static/lib/composer.js
+++ b/static/lib/composer.js
@@ -121,9 +121,16 @@ define('composer', [
 			return composer.load(existingUUID);
 		}
 
-		translator.translate('[[topic:composer.new_topic]]', function(newTopicStr) {
+		var actionText = '[[topic:composer.new_topic]]';
+		if (post.action === 'posts.reply') {
+			actionText = '[[topic:composer.replying_to]]';
+		} else if (post.action === 'posts.edit') {
+			actionText = '[[topic:composer.editing]]';
+		}
+
+		translator.translate(actionText, function(translatedAction) {
 			taskbar.push('composer', uuid, {
-				title: post.title ? post.title : newTopicStr
+				title: translatedAction.replace('%1', '"' + post.title + '"')
 			});
 		});
 


### PR DESCRIPTION
This adds meaningful text in the title attribute of the 'taskbar' icons.

The purpose is to allow the user to hover the icons and see a tooltip explaining what each icon do. For example, new topics will show "New Topic", editing topics will show "Editing 'topic name'" and replying will show "Replying to 'topic name'".

This patch requires a [patch in NodeBB](https://github.com/NodeBB/NodeBB/pull/6693) to work as the Taskbar needs to include the support.