### PR TITLE
Use user default language by reply instead of forum default language

### DIFF
--- a/static/lib/composer.js
+++ b/static/lib/composer.js
@@ -222,9 +222,9 @@ define('composer', [
 		var bodyEl = postContainer.find('textarea');
 		var prevText = bodyEl.val();
 		if (title && (selectedPid || toPid)) {
-			translator.translate('[[modules:composer.user_said_in, ' + username + ', ' + link + ']]\n', config.defaultLang, onTranslated);
+			translator.translate('[[modules:composer.user_said_in, ' + username + ', ' + link + ']]\n', config.userLang || config.defaultLang, onTranslated);
 		} else {
-			translator.translate('[[modules:composer.user_said, ' + username + ']]\n', config.defaultLang, onTranslated);
+			translator.translate('[[modules:composer.user_said, ' + username + ']]\n', config.userLang || config.defaultLang, onTranslated);
 		}
 
 		function onTranslated(translated) {
@@ -236,7 +236,7 @@ define('composer', [
 	};
 
 	composer.newReply = function(tid, toPid, title, text) {
-		translator.translate(text, config.defaultLang, function(translated) {
+		translator.translate(text, config.userLang || config.defaultLang, function(translated) {
 			push({
 				action: 'posts.reply',
 				tid: tid,


### PR DESCRIPTION
We have users with 4 different languages: de, en, nl and ru.
Mostly the users with one language communicates to 98% only with the users of the same language.
Default forum language is english because the first emails should be in English too.

But russian, nl and german users have now "said in" in the responses.
My PR will fix this problem and to 98% the answers will be valid.
May be it would be interesting to use the language of the quoted user, but this could be solved too if you mean so.