### PR TITLE
Make sure `name` is defined before use

### DIFF
--- a/static/lib/composer/formatting.js
+++ b/static/lib/composer/formatting.js
@@ -73,11 +73,12 @@ define('composer/formatting', ['composer/preview', 'composer/resize', 'topicThum
 	};
 
 	formatting.addButton = function (iconClass, onClick, title, name) {
+		name = name || iconClass.replace('fa fa-', '')
 		formattingDispatchTable[name] = onClick;
 		buttons.push({
-			name: name || iconClass.replace('fa fa-', ''),
-			iconClass: iconClass,
-			title: title,
+			name,
+			iconClass,
+			title,
 		});
 	};
 


### PR DESCRIPTION
This fixes a regression introduced by #153.
Since `name` was apparently intended to be optional we need to make sure it is defined before it's 1st use. 
I discovered this bug because it broke some of my custom JS that I use to add buttons to the composer.