### PR TITLE
feat: core submit button dropdown

### DIFF
--- a/static/less/composer.less
+++ b/static/less/composer.less
@@ -107,6 +107,14 @@
 		.composer-submit, .composer-discard {
 			min-width: 106px;
 		}
+
+		.action-bar {
+			.dropdown-menu:empty {
+				& ~ .dropdown-toggle {
+					display: none;
+				}
+			}
+		}
 	}
 
 	.display-scheduler {

--- a/static/lib/composer.js
+++ b/static/lib/composer.js
@@ -482,6 +482,13 @@ define('composer', [
 			tagWhitelist: postData.category ? postData.category.tagWhitelist : ajaxify.data.tagWhitelist,
 			privileges: app.user.privileges,
 			selectedCategory: postData.category,
+			submitOptions: [
+				// Add items using `filter:composer.create`, or just add them to the <ul> in DOM
+				// {
+				// 	action: 'foobar',
+				// 	text: 'Text Label',
+				// }
+			],
 		};
 
 		if (data.mobile) {

--- a/static/templates/composer.tpl
+++ b/static/templates/composer.tpl
@@ -54,7 +54,12 @@
 			<div class="btn-group pull-right action-bar hidden-sm hidden-xs">
 				<button class="btn btn-default composer-discard" data-action="discard" tabindex="-1"><i class="fa fa-times"></i> [[topic:composer.discard]]</button>
 
+				<ul class="dropdown-menu">{{{ each submitOptions }}}<li><a href="#" data-action="{./action}">{./text}</a></li>{{{ end }}}</ul>
 				<button class="btn btn-primary composer-submit" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]]"><i class="fa fa-check"></i> [[topic:composer.submit]]</button>
+				<button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+					<span class="caret"></span>
+					<span class="sr-only">[[topic:composer.additional-options]]</span>
+				</button>
 			</div>
 		</div>
 


### PR DESCRIPTION
Multiple plugins were adding their own dropdown next to the submit button in the composer,
so it is better for the composer to just provide one that can be appended to via hook
(or via direct DOM manipulation)
