### PR TITLE
fix(composer): move attribution line outside of blockquote so @mention triggers notification

### DIFF
--- a/static/lib/composer.js
+++ b/static/lib/composer.js
@@ -225,8 +225,8 @@ define('composer', [
 		const topicLink = `[${escapedTitle}](${postHref})`;
 
 		const quoteKey = useTopicLink ?
-			`> ${translator.compile('modules:composer.user-said-in', data.username, topicLink)}\n>\n` :
-			`> ${translator.compile('modules:composer.user-said', data.username, postHref)}\n>\n`;
+			`${translator.compile('modules:composer.user-said-in', data.username, topicLink)}\n>\n` :
+			`${translator.compile('modules:composer.user-said', data.username, postHref)}\n>\n`;
 
 		if (data.uuid === undefined) {
 			composer.newReply({


### PR DESCRIPTION
## Summary

When using the Quote button, the `@user [wrote](/post/123):` attribution
line was rendered inside the blockquote block due to a leading `> ` in
`quoteKey`. Because the `@mention` was inside a blockquote, the mention
parser did not recognize it, and the quoted user never received a
notification.

This fix removes the leading `> ` so the attribution line appears above
the blockquote, restoring expected mention notification behavior.

**Before:**
> @user [wrote](/post/123):
>
> quoted content

*(no notification sent to @user)*

**After:**
@user [wrote](/post/123):
>
> quoted content

*(notification sent to @user)*

## Changes

- `static/lib/composer.js` — removed `> ` prefix from `quoteKey` in
  both the `useTopicLink` and default branches of `composer.addQuote`

## Test plan

- [ ] Quote another user's post — verify they receive a mention notification
- [ ] Quote a post from a different topic (uses topic link) — same behavior
- [ ] Partial text selection quote — same behavior
