### PR TITLE
fix: let administrators bypass title/post length limits in composer

### DIFF
--- a/static/lib/composer.js
+++ b/static/lib/composer.js
@@ -686,15 +686,15 @@ define('composer', [
 
 		if (uploads.inProgress[post_uuid] && uploads.inProgress[post_uuid].length) {
 			return composerAlert(post_uuid, '[[error:still-uploading]]');
-		} else if (checkTitle && payload.titleLen < parseInt(config.minimumTitleLength, 10)) {
+		} else if (!app.user.isAdmin && checkTitle && payload.titleLen < parseInt(config.minimumTitleLength, 10)) {
 			return composerAlert(post_uuid, '[[error:title-too-short, ' + config.minimumTitleLength + ']]');
-		} else if (checkTitle && payload.titleLen > parseInt(config.maximumTitleLength, 10)) {
+		} else if (!app.user.isAdmin && checkTitle && payload.titleLen > parseInt(config.maximumTitleLength, 10)) {
 			return composerAlert(post_uuid, '[[error:title-too-long, ' + config.maximumTitleLength + ']]');
 		} else if (action === 'topics.post' && !isCategorySelected) {
 			return composerAlert(post_uuid, '[[error:category-not-selected]]');
-		} else if (payload.bodyLen < parseInt(config.minimumPostLength, 10)) {
+		} else if (!app.user.isAdmin && payload.bodyLen < parseInt(config.minimumPostLength, 10)) {
 			return composerAlert(post_uuid, '[[error:content-too-short, ' + config.minimumPostLength + ']]');
-		} else if (payload.bodyLen > parseInt(config.maximumPostLength, 10)) {
+		} else if (!app.user.isAdmin && payload.bodyLen > parseInt(config.maximumPostLength, 10)) {
 			return composerAlert(post_uuid, '[[error:content-too-long, ' + config.maximumPostLength + ']]');
 		} else if (checkTitle && !tags.isEnoughTags(post_uuid)) {
 			return composerAlert(post_uuid, '[[error:not-enough-tags, ' + tags.minTagCount() + ']]');


### PR DESCRIPTION
### Description

NodeBB core skips the minimum/maximum title and content length checks for administrators (`src/topics/create.js` wraps `Topics.checkTitle`/`Topics.checkContent` in `if (!isAdmin)`). The composer, however, enforced these limits client-side for everyone, so an administrator was blocked by the UI before the request reached the server.

This change guards the `title-too-short`/`title-too-long` and `content-too-short`/`content-too-long` checks with `!app.user.isAdmin`, mirroring the server behaviour and the existing `app.user.isAdmin` usage already present in this file for upload limits.

### Code changes

- `static/lib/composer.js`: guard the four title/content length checks in `Composer.check` with `!app.user.isAdmin`.

### Notes

NodeBB core has the same client-side discrepancy in the quick reply; that is addressed in a separate core PR (NodeBB/NodeBB#14399).